### PR TITLE
Always listening demo: update Porcupine

### DIFF
--- a/demo/javascript/always-listening/index.html
+++ b/demo/javascript/always-listening/index.html
@@ -505,7 +505,7 @@
 
       let keywordDetectionCallback = function (keyword) {
         document.querySelector("#inference-box").innerHTML =
-          "detected '" + keyword + " <br/>";
+          "detected '" + keyword + "'" + " <br/>";
       };
 
       let inferenceCallback = function (info) {
@@ -524,34 +524,37 @@
         stop();
       };
 
-      let porcupineRhinoManager;
+      let initCallback = function () {
+        let demoButton = document.querySelector("#demo_button");
+        demoButton.setAttribute("onclick", "stop()");
+        demoButton.innerText = "Stop Demo";
+        demoButton.disabled = false;
+      };
 
       start = function () {
-        porcupineRhinoManager = PorcupineRhinoManager(
-          "/porcupine_worker.js",
-          "/rhino_worker.js",
-          "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
-        );
-
-        porcupineRhinoManager.start(
+        PorcupineRhinoManager.start(
           KEYWORDS_ID,
           SENSITIVITIES,
           keywordDetectionCallback,
           context,
           inferenceCallback,
-          errorCallback
+          errorCallback,
+          initCallback,
+          "/porcupine_worker.js",
+          "/rhino_worker.js",
+          "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
         );
 
         document.querySelector("#inference-box").textContent = "";
 
-        document
-          .querySelector("#demo_button")
-          .setAttribute("onclick", "stop()");
-        document.querySelector("#demo_button").innerText = "Stop Demo";
+        let demoButton = document.querySelector("#demo_button");
+
+        demoButton.innerText = "Initializing...";
+        demoButton.disabled = true;
       };
 
       stop = function () {
-        porcupineRhinoManager.stop();
+        PorcupineRhinoManager.stop();
 
         document
           .querySelector("#demo_button")

--- a/demo/javascript/always-listening/index.html
+++ b/demo/javascript/always-listening/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Rhino with Porcupine Demo</title>
-</head>
-<body>
-<script src="node_modules/@picovoice/web-voice-processor/src/web_voice_processor.js"></script>
-<script src="porcupine_rhino_manager.js"></script>
+  </head>
+  <body>
+    <script src="node_modules/@picovoice/web-voice-processor/src/web_voice_processor.js"></script>
+    <script src="porcupine_rhino_manager.js"></script>
 
-<script>
-    let context = new Uint8Array([
+    <script>
+      let context = new Uint8Array([
         0x72, 0x68, 0x69, 0x6e, 0x6f, 0x31, 0x2e, 0x35, 0x2e, 0x30, 0x09, 0x00, 0x00, 0x00, 0x70, 0x69, 0x63, 0x6f,
         0x76, 0x6f, 0x69, 0x63, 0x65, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x94, 0x16, 0x00, 0x00, 0x63,
         0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x3a, 0x0a, 0x20, 0x20, 0x65, 0x78, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69,
@@ -493,78 +493,103 @@
         ]),
     };
 
-    const SENSITIVITIES = new Float32Array([0.5]);
+      const SENSITIVITIES = new Float32Array([0.5]);
 
-    let errorCallback = function (ex) {
+      let errorCallback = function (ex) {
         alert(ex.toString());
-        document.querySelector("#demo_button").setAttribute("onclick", "start()");
+        document
+          .querySelector("#demo_button")
+          .setAttribute("onclick", "start()");
         document.querySelector("#demo_button").innerText = "Start Demo";
-    };
+      };
 
-    let keywordDetectionCallback = function(keyword) {
-        document.querySelector("#inference-box").innerHTML = "detected '" + keyword + " <br/>";
-    };
+      let keywordDetectionCallback = function (keyword) {
+        document.querySelector("#inference-box").innerHTML =
+          "detected '" + keyword + " <br/>";
+      };
 
-    let inferenceCallback = function (info) {
+      let inferenceCallback = function (info) {
         if (info.isUnderstood) {
-            document.querySelector("#inference-box").innerHTML = "intent : " + info.intent + " <br/>";
-            for (let key in info.slots) {
-                document.querySelector("#inference-box").innerHTML += key + " : " + info.slots[key] + " <br/>";
-            }
+          document.querySelector("#inference-box").innerHTML =
+            "intent : " + info.intent + " <br/>";
+          for (let key in info.slots) {
+            document.querySelector("#inference-box").innerHTML +=
+              key + " : " + info.slots[key] + " <br/>";
+          }
         } else {
-            document.querySelector("#inference-box").innerHTML = "did not understand the spoken command<br/>";
+          document.querySelector("#inference-box").innerHTML =
+            "did not understand the spoken command<br/>";
         }
 
         stop();
-    };
+      };
 
-    let porcupineRhinoManager;
+      let porcupineRhinoManager;
 
-    start = function () {
+      start = function () {
         porcupineRhinoManager = PorcupineRhinoManager(
-            "/porcupine_worker.js",
-            "/rhino_worker.js",
-            "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js");
+          "/porcupine_worker.js",
+          "/rhino_worker.js",
+          "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
+        );
 
-        porcupineRhinoManager.start(KEYWORDS_ID, SENSITIVITIES, keywordDetectionCallback, context, inferenceCallback, errorCallback);
+        porcupineRhinoManager.start(
+          KEYWORDS_ID,
+          SENSITIVITIES,
+          keywordDetectionCallback,
+          context,
+          inferenceCallback,
+          errorCallback
+        );
 
         document.querySelector("#inference-box").textContent = "";
 
-        document.querySelector("#demo_button").setAttribute("onclick", "stop()");
+        document
+          .querySelector("#demo_button")
+          .setAttribute("onclick", "stop()");
         document.querySelector("#demo_button").innerText = "Stop Demo";
-    };
+      };
 
-    stop = function () {
+      stop = function () {
         porcupineRhinoManager.stop();
 
-        document.querySelector("#demo_button").setAttribute("onclick", "start()");
+        document
+          .querySelector("#demo_button")
+          .setAttribute("onclick", "start()");
         document.querySelector("#demo_button").innerText = "Start Demo";
-    };
+      };
+    </script>
 
-</script>
-
-<div style="text-align: center;" style="padding: 2.5em">
-    <h1>
+    <div style="text-align: center;" style="padding: 2.5em;">
+      <h1>
         Rhino Demo
-    </h1>
+      </h1>
 
-    <p style="text-align: left;" style="line-height: 2; font-size: 1.25em">
-        This demo simulates a smart lighting system. Note that you need a  working microphone. This demo is running
-        locally in the browser. You can turn off your internet connection and it will keep working. After pressing start
-        you can issue commands such as "Picovoice, turn on the lights". The full list of commands is available below.
-    </p>
+      <p style="text-align: left;" style="line-height: 2; font-size: 1.25em;">
+        This demo simulates a smart lighting system. Note that you need a
+        working microphone. This demo is running locally in the browser. You can
+        turn off your internet connection and it will keep working. After
+        pressing start you can issue commands such as "Picovoice, turn on the
+        lights". The full list of commands is available below.
+      </p>
 
-    <p style="text-align: center;">
-        <button id="demo_button" onclick="start()" style="font-size: 1.5em; padding: 0.5em 1em">
-            Start Demo
+      <p style="text-align: center;">
+        <button
+          id="demo_button"
+          onclick="start()"
+          style="font-size: 1.5em; padding: 0.5em 1em;"
+        >
+          Start Demo
         </button>
-    </p>
+      </p>
 
-    <div style="text-align: center;" id="inference-box" style="background-color:#00BFFF;min-height: 200px;margin: 2rem 4rem;">
+      <div
+        style="text-align: center;"
+        id="inference-box"
+        style="background-color: #00bfff; min-height: 200px; margin: 2rem 4rem;"
+      ></div>
 
-    </div>
-
-    <div style="text-align:left;">
+      <div style="text-align: left;">
         <pre>
         context: 
           expressions: 
@@ -606,6 +631,6 @@
             state: ["off", "on"] 
         </pre>
       </div>
-</div>
-</body>
+    </div>
+  </body>
 </html>

--- a/demo/javascript/always-listening/porcupine_rhino_manager.js
+++ b/demo/javascript/always-listening/porcupine_rhino_manager.js
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018 Picovoice Inc.
+    Copyright 2018-2020 Picovoice Inc.
     You may not use this file except in compliance with the license. A copy of the license is located in the "LICENSE"
     file accompanying this source.
     Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
@@ -7,54 +7,65 @@
     specific language governing permissions and limitations under the License.
 */
 
-PorcupineRhinoManager = function (porcupineWorkerScript, rhinoWorkerScript, downsamplingScript) {
-    let porcupineWorker;
-    let rhinoWorker;
+PorcupineRhinoManager = function (
+  porcupineWorkerScript,
+  rhinoWorkerScript,
+  downsamplingScript
+) {
+  let porcupineWorker;
+  let rhinoWorker;
 
-    let isWakeWordDetected = false;
+  let isWakeWordDetected = false;
 
-    let start = function (keywordsID, keywordSensitivities, keywordDetectionCallback, context, inferenceCallback, errorCallback) {
-        porcupineWorker = new Worker(porcupineWorkerScript);
-        porcupineWorker.postMessage({
-            command: "init",
-            keywordIDs: keywordsID,
-            sensitivities: keywordSensitivities
-        });
+  let start = function (
+    keywordsID,
+    keywordSensitivities,
+    keywordDetectionCallback,
+    context,
+    inferenceCallback,
+    errorCallback
+  ) {
+    porcupineWorker = new Worker(porcupineWorkerScript);
+    porcupineWorker.postMessage({
+      command: "init",
+      keywordIDs: keywordsID,
+      sensitivities: keywordSensitivities,
+    });
 
-        rhinoWorker = new Worker(rhinoWorkerScript);
-        rhinoWorker.postMessage({command: "init", context: context});
+    rhinoWorker = new Worker(rhinoWorkerScript);
+    rhinoWorker.postMessage({ command: "init", context: context });
 
-        porcupineWorker.onmessage = function (e) {
-            if (!isWakeWordDetected) {
-                isWakeWordDetected = e.data.keyword !== null;
+    porcupineWorker.onmessage = function (e) {
+      if (!isWakeWordDetected) {
+        isWakeWordDetected = e.data.keyword !== null;
 
-                if (isWakeWordDetected) {
-                    keywordDetectionCallback(e.data.keyword);
-                }
-            }
-        };
-
-        rhinoWorker.onmessage = function (e) {
-            inferenceCallback(e.data);
-            isWakeWordDetected = false;
-        };
-
-        WebVoiceProcessor.start([this], downsamplingScript, errorCallback);
-    };
-
-    let stop = function () {
-        WebVoiceProcessor.stop();
-        porcupineWorker.postMessage({command: "release"});
-        rhinoWorker.postMessage({command: 'release'});
-    };
-
-    let processFrame = function (frame) {
-        if (!isWakeWordDetected) {
-            porcupineWorker.postMessage({command: "process", inputFrame: frame});
-        } else {
-            rhinoWorker.postMessage({command: "process", inputFrame: frame});
+        if (isWakeWordDetected) {
+          keywordDetectionCallback(e.data.keyword);
         }
+      }
     };
 
-    return {start: start, processFrame: processFrame, stop: stop}
+    rhinoWorker.onmessage = function (e) {
+      inferenceCallback(e.data);
+      isWakeWordDetected = false;
+    };
+
+    WebVoiceProcessor.start([this], downsamplingScript, errorCallback);
+  };
+
+  let stop = function () {
+    WebVoiceProcessor.stop();
+    porcupineWorker.postMessage({ command: "release" });
+    rhinoWorker.postMessage({ command: "release" });
+  };
+
+  let processFrame = function (frame) {
+    if (!isWakeWordDetected) {
+      porcupineWorker.postMessage({ command: "process", inputFrame: frame });
+    } else {
+      rhinoWorker.postMessage({ command: "process", inputFrame: frame });
+    }
+  };
+
+  return { start: start, processFrame: processFrame, stop: stop };
 };


### PR DESCRIPTION
Updates the Porcupine submodule and use the new initialization callback in Porcupine binding to start the workers / web voice processor in the always-listening demo.

The demo button will briefly go from "Start" to "Initializing..." to "Stop" as it takes the WASM asynchronous loading into account before attempting to run porcupine.

This does not (yet) change the rhinoWorker logic which will continue to poll isLoaded for its own WASM module.