### PR TITLE
fix compile warning of missing C bool in go demo

### DIFF
--- a/binding/go/rhino_posix.go
+++ b/binding/go/rhino_posix.go
@@ -18,6 +18,7 @@ package rhino
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 typedef int32_t (*pv_rhino_init_func)(const char *, const char *, float, void **);
 


### PR DESCRIPTION
include of stdbool.h was missing for the go demos to compile properly