### PR TITLE
implement error trait for rhinoerror

### DIFF
--- a/binding/rust/src/rhino.rs
+++ b/binding/rust/src/rhino.rs
@@ -111,6 +111,8 @@ impl std::fmt::Display for RhinoError {
     }
 }
 
+impl std::error::Error for RhinoError {}
+
 pub struct RhinoInference {
     pub is_understood: bool,
     pub intent: Option<String>,


### PR DESCRIPTION
This allows it to be used in a more general way, along with the `?` operator e.g.

```rust
fn main() -> Result<(), Box<dyn Error>> { todo!() }
```